### PR TITLE
9 sort column

### DIFF
--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -1,3 +1,7 @@
+import {
+  SortAscendingOutlined,
+  SortDescendingOutlined,
+} from '@ant-design/icons';
 import TablePagination from './TablePagination';
 import {
   TableContainer,
@@ -5,11 +9,20 @@ import {
   TableData,
   TableHeader,
   TableHeaderGroup,
+  TableHeaderIcon,
   TableRow,
 } from './TableStyle';
 
+export type SortOrder = false | 'asc' | 'desc';
+
 interface TableProps {
-  columns: { title: string; dataIndex: string; key: string }[];
+  columns: {
+    title: string;
+    dataIndex: string;
+    key: string;
+    sortOrder?: SortOrder;
+  }[];
+  onSort: (columnKey: string) => void;
   dataSource?: any[];
   pagination: {
     currentPage: number;
@@ -22,6 +35,7 @@ interface TableProps {
 
 const Table: React.FC<TableProps> = ({
   columns,
+  onSort,
   dataSource = [],
   pagination,
 }: TableProps) => {
@@ -31,7 +45,22 @@ const Table: React.FC<TableProps> = ({
         <TableHeaderGroup>
           <TableRow>
             {columns.map((column) => (
-              <TableHeader key={column.dataIndex}>{column.title}</TableHeader>
+              <TableHeader
+                key={column.dataIndex}
+                onClick={() => onSort(column.key)}
+              >
+                <span>{column.title}</span>
+                {column.sortOrder &&
+                  (column.sortOrder === 'asc' ? (
+                    <TableHeaderIcon>
+                      <SortAscendingOutlined />
+                    </TableHeaderIcon>
+                  ) : (
+                    <TableHeaderIcon>
+                      <SortDescendingOutlined />
+                    </TableHeaderIcon>
+                  ))}
+              </TableHeader>
             ))}
           </TableRow>
         </TableHeaderGroup>

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -22,7 +22,7 @@ interface TableProps {
     key: string;
     sortOrder?: SortOrder;
   }[];
-  onSort: (columnKey: string) => void;
+  onSort: (columnKey: string, columnDataIndex?: string) => void;
   dataSource?: any[];
   pagination: {
     currentPage: number;
@@ -47,7 +47,7 @@ const Table: React.FC<TableProps> = ({
             {columns.map((column) => (
               <TableHeader
                 key={column.dataIndex}
-                onClick={() => onSort(column.key)}
+                onClick={() => onSort(column.key, column.dataIndex)}
               >
                 <span>{column.title}</span>
                 {column.sortOrder &&

--- a/src/components/table/TableStyle.ts
+++ b/src/components/table/TableStyle.ts
@@ -26,6 +26,11 @@ export const TableHeader = styled.th`
   vertical-align: middle;
 `;
 
+export const TableHeaderIcon = styled.span`
+  float: right;
+  color: #bfbfbf;
+`;
+
 export const TableData = styled.td`
   vertical-align: middle;
 `;

--- a/src/pages/patientInfo/PatientInfo.tsx
+++ b/src/pages/patientInfo/PatientInfo.tsx
@@ -29,8 +29,8 @@ const PatientInfo: React.FC<PatientProps> = ({
     {
       title: '환자 id',
       dataIndex: 'personID',
-      key: 'personID',
-      sortOrder: sortedInfo.columnKey === 'personID' && sortedInfo.order,
+      key: 'person_id',
+      sortOrder: sortedInfo.columnKey === 'person_id' && sortedInfo.order,
     },
     {
       title: '성별',
@@ -41,8 +41,8 @@ const PatientInfo: React.FC<PatientProps> = ({
     {
       title: '생년월일',
       dataIndex: 'birthDatetime',
-      key: 'birthDatetime',
-      sortOrder: sortedInfo.columnKey === 'birthDatetime' && sortedInfo.order,
+      key: 'birth',
+      sortOrder: sortedInfo.columnKey === 'birth' && sortedInfo.order,
     },
     {
       title: '나이',
@@ -64,8 +64,8 @@ const PatientInfo: React.FC<PatientProps> = ({
     {
       title: '사망 여부',
       dataIndex: 'isDeath',
-      key: 'isDeath',
-      sortOrder: sortedInfo.columnKey === 'isDeath' && sortedInfo.order,
+      key: 'death',
+      sortOrder: sortedInfo.columnKey === 'death' && sortedInfo.order,
     },
   ];
 
@@ -74,7 +74,12 @@ const PatientInfo: React.FC<PatientProps> = ({
       try {
         // const {
         //   data: { patient },
-        // } = await patientService.getPatientList(currentPage, rowsPerPage);
+        // } = await patientService.getPatientList(
+        //   currentPage,
+        //   rowsPerPage,
+        //   sortedInfo.order === 'desc' ? true : false,
+        //   sortedInfo.columnKey,
+        // );
         // setData(patient);
 
         /**
@@ -85,7 +90,7 @@ const PatientInfo: React.FC<PatientProps> = ({
         console.log(error);
       }
     })();
-  }, [currentPage, rowsPerPage, patientService]);
+  }, [currentPage, rowsPerPage, patientService, sortedInfo]);
 
   const handlePageClick = (page: number) => {
     setCurrentPage(page);

--- a/src/pages/patientInfo/PatientInfo.tsx
+++ b/src/pages/patientInfo/PatientInfo.tsx
@@ -13,6 +13,7 @@ interface PatientProps {
 type SortedInfo = {
   order: SortOrder;
   columnKey: string;
+  columnDataIndex?: string; // for dummy data
 };
 
 const PatientInfo: React.FC<PatientProps> = ({
@@ -24,6 +25,7 @@ const PatientInfo: React.FC<PatientProps> = ({
   const [sortedInfo, setSortedInfo] = useState<SortedInfo>({
     order: false,
     columnKey: '',
+    columnDataIndex: '',
   });
   const columns = [
     {
@@ -85,7 +87,14 @@ const PatientInfo: React.FC<PatientProps> = ({
         /**
          * API 500 오류로 더미 데이터 사용
          */
-        setData(generatePatientList(currentPage, rowsPerPage));
+        setData(
+          generatePatientList(
+            currentPage,
+            rowsPerPage,
+            sortedInfo.order === 'desc' ? true : false,
+            sortedInfo.columnDataIndex,
+          ),
+        );
       } catch (error) {
         console.log(error);
       }
@@ -104,7 +113,7 @@ const PatientInfo: React.FC<PatientProps> = ({
     setRowsPerPage(newRowsPerPage);
   };
 
-  const handleColumnSort = (columnKey: string) => {
+  const handleColumnSort = (columnKey: string, columnDataIndex?: string) => {
     setSortedInfo((sortedInfo) => ({
       order:
         sortedInfo?.order === 'asc'
@@ -113,6 +122,7 @@ const PatientInfo: React.FC<PatientProps> = ({
           ? false
           : 'asc',
       columnKey,
+      columnDataIndex,
     }));
   };
 

--- a/src/pages/patientInfo/PatientInfo.tsx
+++ b/src/pages/patientInfo/PatientInfo.tsx
@@ -1,13 +1,19 @@
 import { useEffect, useState } from 'react';
-import { PatientList } from 'utils/types/patient';
-import Table from 'components/table';
-import { Container } from './PatientInfoStyle';
 import PatientService from 'services/patient';
+import { PatientList } from 'utils/types/patient';
 import { generatePatientList } from 'utils/dummy/patientList';
+import Table from 'components/table';
+import { SortOrder } from 'components/table/Table';
+import { Container } from './PatientInfoStyle';
 
 interface PatientProps {
   patientService: PatientService;
 }
+
+type SortedInfo = {
+  order: SortOrder;
+  columnKey: string;
+};
 
 const PatientInfo: React.FC<PatientProps> = ({
   patientService,
@@ -15,14 +21,52 @@ const PatientInfo: React.FC<PatientProps> = ({
   const [data, setData] = useState<PatientList['patient']>();
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(10);
+  const [sortedInfo, setSortedInfo] = useState<SortedInfo>({
+    order: false,
+    columnKey: '',
+  });
   const columns = [
-    { title: '환자 id', dataIndex: 'personID', key: 'personID' },
-    { title: '성별', dataIndex: 'gender', key: 'gender' },
-    { title: '생년월일', dataIndex: 'birthDatetime', key: 'birthDatetime' },
-    { title: '나이', dataIndex: 'age', key: 'age' },
-    { title: '인종', dataIndex: 'race', key: 'race' },
-    { title: '민족', dataIndex: 'ethnicity', key: 'ethnicity' },
-    { title: '사망 여부', dataIndex: 'isDeath', key: 'isDeath' },
+    {
+      title: '환자 id',
+      dataIndex: 'personID',
+      key: 'personID',
+      sortOrder: sortedInfo.columnKey === 'personID' && sortedInfo.order,
+    },
+    {
+      title: '성별',
+      dataIndex: 'gender',
+      key: 'gender',
+      sortOrder: sortedInfo.columnKey === 'gender' && sortedInfo.order,
+    },
+    {
+      title: '생년월일',
+      dataIndex: 'birthDatetime',
+      key: 'birthDatetime',
+      sortOrder: sortedInfo.columnKey === 'birthDatetime' && sortedInfo.order,
+    },
+    {
+      title: '나이',
+      dataIndex: 'age',
+      key: 'age',
+    },
+    {
+      title: '인종',
+      dataIndex: 'race',
+      key: 'race',
+      sortOrder: sortedInfo.columnKey === 'race' && sortedInfo.order,
+    },
+    {
+      title: '민족',
+      dataIndex: 'ethnicity',
+      key: 'ethnicity',
+      sortOrder: sortedInfo.columnKey === 'ethnicity' && sortedInfo.order,
+    },
+    {
+      title: '사망 여부',
+      dataIndex: 'isDeath',
+      key: 'isDeath',
+      sortOrder: sortedInfo.columnKey === 'isDeath' && sortedInfo.order,
+    },
   ];
 
   useEffect(() => {
@@ -55,11 +99,24 @@ const PatientInfo: React.FC<PatientProps> = ({
     setRowsPerPage(newRowsPerPage);
   };
 
+  const handleColumnSort = (columnKey: string) => {
+    setSortedInfo((sortedInfo) => ({
+      order:
+        sortedInfo?.order === 'asc'
+          ? 'desc'
+          : sortedInfo?.order === 'desc'
+          ? false
+          : 'asc',
+      columnKey,
+    }));
+  };
+
   return (
     <Container>
       {data && (
         <Table
           columns={columns}
+          onSort={handleColumnSort}
           dataSource={data.list.map((patient) => ({
             ...patient,
             isDeath: patient.isDeath ? 'T' : 'F',

--- a/src/services/patient.ts
+++ b/src/services/patient.ts
@@ -24,9 +24,28 @@ class PatientService {
   getPatientList = (
     page = 1,
     length = 10,
+    order_desc = false,
+    order_column?: string,
   ): Promise<AxiosResponse<PatientList>> => {
+    type Params = {
+      page: number;
+      length: number;
+      order_desc: boolean;
+      order_column?: string;
+    };
+
+    const params: Params = {
+      page,
+      length,
+      order_desc,
+    };
+
+    if (order_column) {
+      params.order_column = order_column;
+    }
+
     return this.httpClient.get<PatientList>(PATIENT_LIST_URL, {
-      params: { page, length },
+      params,
     });
   };
 

--- a/src/utils/dummy/patientList.ts
+++ b/src/utils/dummy/patientList.ts
@@ -3,6 +3,8 @@ import { PatientList } from 'utils/types/patient';
 export const generatePatientList = (
   page: number,
   length: number,
+  order_desc = false,
+  order_column?: string,
 ): PatientList['patient'] => {
   const totalLength = 1000;
   const list = [];
@@ -11,15 +13,38 @@ export const generatePatientList = (
       personID: i,
       age: 0,
       birthDatetime: 'string',
-      ethnicity: 'string',
-      gender: 'string',
-      isDeath: true,
-      race: 'string',
+      ethnicity: getRandomItem(['nonhispanic', 'hispanic']),
+      gender: getRandomItem(['M', 'F']),
+      isDeath: getRandomItem([true, false]),
+      race: getRandomItem(['other', 'native', 'black', 'white', 'asian']),
     });
   }
+
+  if (order_column) {
+    list.sort((a: any, b: any) => {
+      if (order_desc) {
+        return a[order_column] < b[order_column]
+          ? 1
+          : a[order_column] > b[order_column]
+          ? -1
+          : 0;
+      }
+      return a[order_column] < b[order_column]
+        ? -1
+        : a[order_column] > b[order_column]
+        ? 1
+        : 0;
+    });
+    console.log(list);
+  }
+
   return {
     list,
     page,
     totalLength,
   };
+};
+
+const getRandomItem = (items: any[]) => {
+  return items[Math.floor(Math.random() * items.length)];
 };


### PR DESCRIPTION
## Summary

테이블 정렬 기능 추가

## What I did

- API 오류 문제로 dummy 데이터 기준으로 구현
- 특정 컬럼으로 정렬 (환자 id, 성별, 생년월일, 인종, 민족, 사망 여부)
- 테이블 헤더에 정렬 아이콘 표시

![image](https://user-images.githubusercontent.com/37607373/137590454-53c39f1d-d08c-42bb-954e-2963e8ea8ac5.png)

Closes #9 
