### PR TITLE
Fix: [#17] Hide sub row when sorting or filtering

### DIFF
--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -30,13 +30,7 @@ import {
 export type SortOrder = false | 'asc' | 'desc';
 
 interface TableProps {
-  columns: {
-    title: string;
-    dataIndex: string;
-    key: string;
-    sortOrder?: SortOrder;
-    filters?: Filter[];
-  }[];
+  columns: Column[];
   onSort: ({ order, columnKey, columnDataIndex }: SortedInfo) => void;
   onFilter: ({ columnKey, filter }: FilteredInfo) => void;
   dataSource?: any[];
@@ -68,6 +62,16 @@ const Table: React.FC<TableProps> = ({
   const [isDetailRowOpen, setIsDetailRowOpen] = useState(false);
   const [detailRowIndex, setDetailRowIndex] = useState(-1);
 
+  const handleSort = (column: Column) => {
+    initDataDetail();
+
+    onSort({
+      order: column.sortOrder ? column.sortOrder : false,
+      columnKey: column.key,
+      columnDataIndex: column.dataIndex,
+    });
+  };
+
   const handleFilterBar = (columnKey: string, filters?: Filter[]) => {
     if (columnKey !== currentFilters.columnKey) {
       setCurrentFilters({ columnKey, filters: filters! });
@@ -80,6 +84,8 @@ const Table: React.FC<TableProps> = ({
   };
 
   const handleSelectFilter = (filter: Filter) => {
+    initDataDetail();
+
     const newFilters = [...currentFilters.filters];
     setCurrentFilters((currentFilters) => ({
       ...currentFilters,
@@ -97,15 +103,22 @@ const Table: React.FC<TableProps> = ({
   };
 
   const handleRangeFilter = (filter: Filter) => {
+    initDataDetail();
+
     onFilter({
       columnKey: currentFilters.columnKey,
       filter,
     });
   };
 
+  const initDataDetail = () => {
+    setDetailRowIndex(-1);
+    setIsDetailRowOpen(false);
+  };
+
   const handleDataDetail = (index: number) => {
     if (detailRowIndex > -1 && detailRowIndex === index) {
-      setIsDetailRowOpen(false);
+      initDataDetail();
       return;
     }
     setDetailRowIndex(index);
@@ -123,15 +136,7 @@ const Table: React.FC<TableProps> = ({
             {columns.map((column) => (
               <TableHeader key={column.dataIndex}>
                 <TableHeaderContainer>
-                  <TableHeaderTitle
-                    onClick={() =>
-                      onSort({
-                        order: column.sortOrder ? column.sortOrder : false,
-                        columnKey: column.key,
-                        columnDataIndex: column.dataIndex,
-                      })
-                    }
-                  >
+                  <TableHeaderTitle onClick={() => handleSort(column)}>
                     {column.title}
                     <TableHeaderIcon>
                       {column.sortOrder !== undefined && (
@@ -223,6 +228,14 @@ const Table: React.FC<TableProps> = ({
 };
 
 export default Table;
+
+export type Column = {
+  title: string;
+  dataIndex: string;
+  key: string;
+  sortOrder?: SortOrder;
+  filters?: Filter[];
+};
 
 export type SortedInfo = {
   order: SortOrder;

--- a/src/pages/patientInfo/PatientInfo.tsx
+++ b/src/pages/patientInfo/PatientInfo.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import PatientService, { PatientListParams } from 'services/patient';
-import { PatientBrief, PatientList } from 'utils/types/patient';
+import { PatientList } from 'utils/types/patient';
 import Table from 'components/table';
 import {
+  Column,
   DetailInfo,
   FilteredInfo,
   SortedInfo,
-  SortOrder,
 } from 'components/table/Table';
 import { Container } from './PatientInfoStyle';
 import { Filter } from 'components/table/TableFilterBar';
@@ -28,7 +28,7 @@ const PatientInfo: React.FC<PatientProps> = ({
   });
   const [filteredInfo, setFilteredInfo] = useState<FilteredInfo[]>([]);
   const [filters, setFilters] = useState<Filters>();
-  const [columns, setColumns] = useState<Columns[]>([]);
+  const [columns, setColumns] = useState<Column[]>([]);
   const [brief, setBrief] = useState<DetailInfo[]>([]);
 
   useEffect(() => {
@@ -268,14 +268,6 @@ const PatientInfo: React.FC<PatientProps> = ({
 };
 
 export default PatientInfo;
-
-type Columns = {
-  title: string;
-  dataIndex: string;
-  key: string;
-  sortOrder?: SortOrder;
-  filters?: Filter[];
-};
 
 type Filters = {
   [key: string]: Filter[];


### PR DESCRIPTION
## Summary

정렬 또는 필터링 시 기존 상세 정보가 사라지지 않는 버그 해결

## What I did

- 정렬 또는 필터링 시 상세 정보 숨기기

Closes #17 
