### PR TITLE
Fix: [#17] Initialize and hide detail info whenever data is updated

### DIFF
--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -1,4 +1,4 @@
-import { Fragment, MouseEvent, useState } from 'react';
+import { Fragment, MouseEvent, useEffect, useState } from 'react';
 import {
   CaretDownOutlined,
   CaretUpOutlined,
@@ -64,8 +64,6 @@ const Table: React.FC<TableProps> = ({
   const [detailRowIndex, setDetailRowIndex] = useState(-1);
 
   const handleSort = (column: Column) => {
-    initDataDetail();
-
     onSort({
       order: column.sortOrder ? column.sortOrder : false,
       columnKey: column.key,
@@ -91,8 +89,6 @@ const Table: React.FC<TableProps> = ({
   };
 
   const handleSelectFilter = (filter: Filter) => {
-    initDataDetail();
-
     const newFilters = [...currentFilters.filters];
     setCurrentFilters((currentFilters) => ({
       ...currentFilters,
@@ -110,22 +106,16 @@ const Table: React.FC<TableProps> = ({
   };
 
   const handleRangeFilter = (filter: Filter) => {
-    initDataDetail();
-
     onFilter({
       columnKey: currentFilters.columnKey,
       filter,
     });
   };
 
-  const initDataDetail = () => {
-    setDetailRowIndex(-1);
-    setIsDetailRowOpen(false);
-  };
-
   const handleDataDetail = (index: number) => {
     if (detailRowIndex > -1 && detailRowIndex === index) {
-      initDataDetail();
+      setDetailRowIndex(-1);
+      setIsDetailRowOpen(false);
       return;
     }
     setDetailRowIndex(index);
@@ -133,6 +123,14 @@ const Table: React.FC<TableProps> = ({
 
     onShowDetail(index);
   };
+
+  useEffect(() => {
+    if (detailInfo && detailInfo.length > 0) {
+      return;
+    }
+    setDetailRowIndex(-1);
+    setIsDetailRowOpen(false);
+  }, [dataSource, detailInfo]);
 
   return (
     <TableContainer>

--- a/src/pages/patientInfo/PatientInfo.tsx
+++ b/src/pages/patientInfo/PatientInfo.tsx
@@ -174,6 +174,8 @@ const PatientInfo: React.FC<PatientProps> = ({
             align: 'center',
           },
         ]);
+
+        setBrief([]);
       } catch (error) {
         console.log(error);
       }


### PR DESCRIPTION
## Summary

데이터가 업데이트되는 모든 경우에 상세 정보가 초기화되도록 수정

## What I did

- 정렬, 필터링, 페이지네이션 등 데이터가 변경될 때마다 기존 상세 정보 값 초기화
- 상세 정보가 존재하는 경우 제외하고 항상 sub row 닫기

Closes #17 
