### PR TITLE
Fix: [#23] Go first page when filtering

### DIFF
--- a/src/pages/patientInfo/PatientInfo.tsx
+++ b/src/pages/patientInfo/PatientInfo.tsx
@@ -92,6 +92,8 @@ const PatientInfo: React.FC<PatientProps> = ({
           ethnicity,
           death,
         });
+
+        setCurrentPage(1);
       })();
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
## Summary

필터링 적용 시 기존 페이지 정보 적용되는 문제 해결

## What I did

- 필터링 적용 시 1페이지 데이터 호출

Closes #23 
